### PR TITLE
[DOCS] Add code samples to workflow

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -4,6 +4,10 @@ sources:
     latest:
         inputs:
             - location: registry.speakeasyapi.dev/moov/moov/api-latest
+        overlays:
+            - location: .speakeasy/speakeasy-modifications-overlay.yaml
+        registry:
+            location: registry.speakeasyapi.dev/moov/moov/latest
 targets:
     moov:
         target: typescript
@@ -11,3 +15,9 @@ targets:
         publish:
             npm:
                 token: $npm_token
+        codeSamples:
+          registry:
+              location: registry.speakeasyapi.dev/moov/moov/latest-typescript-code-samples
+          labelOverride:
+              fixedValue: Typescript (SDK)
+          blocking: false


### PR DESCRIPTION
Trying to add the code samples workflow to all SDKs. Used the [PHP SDK](https://github.com/moovfinancial/moov-php/blob/main/.speakeasy/workflow.yaml) as an example since it already referenced `codeSamples`.  Some minor inconsistencies between the two - not entirely sure what's default or required between them all.