### PR TITLE
FE-2050 Remove sdk_generation npm_token

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -26,6 +26,5 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      npm_token: ${{ secrets.NPM_TOKEN }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Speakeasy reports that they've fixed the issue on their side, and an NPM token is no longer needed when authenticating through OIDC.