### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@moovio/sdk",
   "version": "0.0.0-dev.24",
   "author": "Moov",
+  "license": "Apache-2.0",
   "bin": {
     "mcp": "bin/mcp-server.js"
   },


### PR DESCRIPTION
## Summary

- add Apache-2.0 license metadata to the package manifest
- align npm metadata with the repository license

## Verification

- `npm view @moovio/sdk@latest name version license repository homepage bugs --json`
- `node -e "const p=require('./package.json'); if (p.license !== 'Apache-2.0') throw new Error('license mismatch'); console.log(p.name, p.version, p.license)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`

Note: the currently published npm package is `25.7.0`; the source manifest on `main` currently reports `0.0.0-dev.24`.
