### PR TITLE
fix(moov-typescript): remove src files from npm package output

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -36,7 +36,27 @@ typescript:
     dependencies: {}
     devDependencies: {}
     peerDependencies: {}
-  additionalPackageJSON: {}
+  additionalPackageJSON:
+    files:
+      - bin
+      - funcs
+      - hooks
+      - lib
+      - mcp-server
+      - models
+      - sdk
+      - types
+      - index.js
+      - index.d.ts
+      - index.js.map
+      - index.d.ts.map
+      - core.js
+      - core.d.ts
+      - core.js.map
+      - core.d.ts.map
+      - FUNCTIONS.md
+      - RUNTIMES.md
+      - USAGE.md
   additionalScripts: {}
   alwaysIncludeInboundAndOutbound: false
   apiPromiseHelpers: false

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -52,15 +52,13 @@ typescript:
       - types
       - index.js
       - index.d.ts
-      - index.js.map
-      - index.d.ts.map
       - core.js
       - core.d.ts
-      - core.js.map
-      - core.d.ts.map
       - FUNCTIONS.md
       - RUNTIMES.md
       - USAGE.md
+      # Maps point at src/ which is not published; exclude to avoid broken maps.
+      - "!**/*.map"
   additionalScripts: {}
   alwaysIncludeInboundAndOutbound: false
   apiPromiseHelpers: false

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -37,6 +37,10 @@ typescript:
     devDependencies: {}
     peerDependencies: {}
   additionalPackageJSON:
+    # MCP bin is an ESM bundle in a CJS package; Node needs syntax detection
+    # (default since 22.12) for `npx ... mcp start` to work.
+    engines:
+      node: ">=22.12"
     files:
       - bin
       - funcs

--- a/package.json
+++ b/package.json
@@ -21,15 +21,12 @@
     "types",
     "index.js",
     "index.d.ts",
-    "index.js.map",
-    "index.d.ts.map",
     "core.js",
     "core.d.ts",
-    "core.js.map",
-    "core.d.ts.map",
     "FUNCTIONS.md",
     "RUNTIMES.md",
-    "USAGE.md"
+    "USAGE.md",
+    "!**/*.map"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   },
   "main": "./index.js",
   "sideEffects": false,
+  "engines": {
+    "node": ">=22.12"
+  },
   "files": [
     "bin",
     "funcs",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,27 @@
   },
   "main": "./index.js",
   "sideEffects": false,
+  "files": [
+    "bin",
+    "funcs",
+    "hooks",
+    "lib",
+    "mcp-server",
+    "models",
+    "sdk",
+    "types",
+    "index.js",
+    "index.d.ts",
+    "index.js.map",
+    "index.d.ts.map",
+    "core.js",
+    "core.d.ts",
+    "core.js.map",
+    "core.d.ts.map",
+    "FUNCTIONS.md",
+    "RUNTIMES.md",
+    "USAGE.md"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/moovfinancial/moov-typescript.git"


### PR DESCRIPTION
Removes a number of development files from the final npm package output.


Metric | Before | After
-- | -- | --
Files | 7,013 | 2,721
Package size | 3.9 MB | 1.4 MB
Unpacked | 30.0 MB | 11.2 MB

Also bumps the Node requirement to get the MCP running
